### PR TITLE
Ignore keyword 'hide_props_region'

### DIFF
--- a/io_scene_ac3d/__init__.py
+++ b/io_scene_ac3d/__init__.py
@@ -166,7 +166,8 @@ class AC3D_OT_Import(Operator, ImportHelper):
                                             "axis_up",
                                             "filter_glob",
                                             "rotation",
-                                            "translation"))
+                                            "translation",
+                                            "hide_props_region"))
 
         eul = Euler((radians(self.rotation[0]),
                      radians(self.rotation[1]),


### PR DESCRIPTION
Workaround a blender API breaking change.